### PR TITLE
Change property name in NcMethodResultObjectPropertiesSetValidation

### DIFF
--- a/device-configuration/README.md
+++ b/device-configuration/README.md
@@ -68,7 +68,7 @@ interface NcMethodResultBulkValuesHolder: NcMethodResult {
 
 ```typescript
 interface NcMethodResultObjectPropertiesSetValidation: NcMethodResult {
-    attribute sequence<NcObjectPropertiesSetValidation>    value; // Object properties set path validations
+    attribute sequence<NcObjectPropertiesSetValidation>    values; // Object properties set path validations
 };
 ```
 

--- a/device-configuration/models/datatypes/NcMethodResultObjectPropertiesSetValidation.json
+++ b/device-configuration/models/datatypes/NcMethodResultObjectPropertiesSetValidation.json
@@ -5,7 +5,7 @@
   "fields": [
     {
       "description": "Object properties set path validations",
-      "name": "value",
+      "name": "values",
       "typeName": "NcObjectPropertiesSetValidation",
       "isNullable": false,
       "isSequence": true,


### PR DESCRIPTION
Property is a sequence of values: value-->values
This makes it consistent with NcObjectPropertiesHolder and NcBulkValuesHolder