### PR TITLE
Update models to extend reset to status messages

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -166,7 +166,7 @@ Receiver monitors MUST maintain a 1 to 1 relationship between their role and the
     [element("4p11")]    readonly    attribute    NcStreamStatus    streamStatus;    // Stream status property
     [element("4p12")]    readonly    attribute    NcString?    streamStatusMessage;    // Stream status message property
     [element("4p13")]    readonly    attribute    NcUint64    streamStatusTransitionCounter;    // Stream status transition counter property
-    [element("4p14")]                attribute    NcBoolean    autoResetCounters;    // Automatic reset counters property (default: true)
+    [element("4p14")]                attribute    NcBoolean    autoResetCountersAndMessages;    // Automatic reset counters and status messages property (default: true)
 
     // Gets the lost packet counters
     [element("4m1")]    NcMethodResultCounters GetLostPacketCounters();
@@ -174,8 +174,8 @@ Receiver monitors MUST maintain a 1 to 1 relationship between their role and the
     // Gets the late packet counters
     [element("4m2")]    NcMethodResultCounters GetLatePacketCounters();
 
-    // Resets ALL counters
-    [element("4m3")]    NcMethodResult ResetCounters();
+    // Resets ALL counters and status messages
+    [element("4m3")]    NcMethodResult ResetCountersAndMessages();
 };
 ```
 
@@ -205,12 +205,12 @@ Sender monitors MUST maintain a 1 to 1 relationship between their role and the t
     [element("4p11")]    readonly    attribute    NcEssenceStatus    essenceStatus;    // Essence status property
     [element("4p12")]    readonly    attribute    NcString?    essenceStatusMessage;    // Essence status message property
     [element("4p13")]    readonly    attribute    NcUint64    essenceStatusTransitionCounter;    // Essence status transition counter property
-    [element("4p14")]                attribute    NcBoolean    autoResetCounters;    // Automatic reset counters property (default: true)
+    [element("4p14")]                attribute    NcBoolean    autoResetCountersAndMessages;    // Automatic reset counters and status messages property (default: true)
 
     // Gets the transmission error counters
     [element("4m1")]    NcMethodResultCounters GetTransmissionErrorCounters();
 
-    // Resets ALL counters
-    [element("4m2")]    NcMethodResult ResetCounters();
+    // Resets ALL counters and status messages
+    [element("4m2")]    NcMethodResult ResetCountersAndMessages();
 };
 ```

--- a/monitoring/models/classes/1.2.2.1.json
+++ b/monitoring/models/classes/1.2.2.1.json
@@ -192,12 +192,12 @@
       "constraints": null
     },
     {
-      "description": "Automatic reset counters property (default: true)",
+      "description": "Automatic reset counters and status messages property (default: true)",
       "id": {
         "level": 4,
         "index": 14
       },
-      "name": "autoResetCounters",
+      "name": "autoResetCountersAndMessages",
       "typeName": "NcBoolean",
       "isReadOnly": false,
       "isNullable": false,
@@ -230,12 +230,12 @@
       "isDeprecated": false
     },
     {
-      "description": "Resets ALL counters",
+      "description": "Resets ALL counters and status messages",
       "id": {
         "level": 4,
         "index": 3
       },
-      "name": "ResetCounters",
+      "name": "ResetCountersAndMessages",
       "resultDatatype": "NcMethodResult",
       "parameters": [],
       "isDeprecated": false

--- a/monitoring/models/classes/1.2.2.2.json
+++ b/monitoring/models/classes/1.2.2.2.json
@@ -192,12 +192,12 @@
       "constraints": null
     },
     {
-      "description": "Automatic reset counters property (default: true)",
+      "description": "Automatic reset counters and status messages property (default: true)",
       "id": {
         "level": 4,
         "index": 14
       },
-      "name": "autoResetCounters",
+      "name": "autoResetCountersAndMessages",
       "typeName": "NcBoolean",
       "isReadOnly": false,
       "isNullable": false,
@@ -219,12 +219,12 @@
       "isDeprecated": false
     },
     {
-      "description": "Resets ALL counters",
+      "description": "Resets ALL counters and status messages",
       "id": {
         "level": 4,
         "index": 2
       },
-      "name": "ResetCounters",
+      "name": "ResetCountersAndMessages",
       "resultDatatype": "NcMethodResult",
       "parameters": [],
       "isDeprecated": false


### PR DESCRIPTION
- renamed "autoResetCounters" to "autoResetCountersAndMessages"
- renamed "ResetCounters" to "ResetCountersAndMessages"
- refactored some descriptions in line with the above changes